### PR TITLE
:heart_eyes: according to official docs the `.env` file is for defaul…

### DIFF
--- a/scripts/run-images.sh
+++ b/scripts/run-images.sh
@@ -7,8 +7,6 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-source "${DIR}/../.env"
-
 if [ "$1" = '--pull' ]; then
     docker pull "${FROM}:${ODOO_VERSION}"
 fi

--- a/scripts/run-patches.sh
+++ b/scripts/run-patches.sh
@@ -5,8 +5,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # Only for framework patches
 APPLY_DIR="${DIR}/../vendor/odoo/cc"
 
-# Load environment
-source "${DIR}/../.env"
-
 # Source the patches
 source <(docker run ${IMAGE}:${ODOO_VERSION} patches)


### PR DESCRIPTION
…t values for environment variables which Compose automatically looks for. Why to source them manually? Values set in the shell environment override thouse set in the `.env` file. Manyally sourcing the `.env` brakes the intended behaviour